### PR TITLE
Added event bus

### DIFF
--- a/purrplingbot.js
+++ b/purrplingbot.js
@@ -87,7 +87,7 @@ function load_plugins(pluginDir, bot) {
               console.error("<" + file + "> Can't register command: " + cmd);
               console.error(err);
             }
-          })
+          });
           plugins[file] = plugin; //Add plugin to plugin registry
         }
       } catch (err) {

--- a/purrplingbot.js
+++ b/purrplingbot.js
@@ -7,6 +7,8 @@ const CODENAME = "Chiara";
 class BotEventBus extends EventEmmiter {}
 const eventBus = new BotEventBus;
 
+var plugins = {};
+
 require('console-stamp')(console, 'dd.mm.yyyy HH:MM:ss.l');
 console.log("Starting PurrplingBot version " + VERSION + " '" + CODENAME + "'");
 
@@ -86,6 +88,7 @@ function load_plugins(pluginDir, bot) {
               console.error(err);
             }
           })
+          plugins[file] = plugin; //Add plugin to plugin registry
         }
       } catch (err) {
         console.error("Error while loading plugin ''" + file + "'' ");
@@ -156,3 +159,11 @@ bot.on('message', function(user, userID, channelID, message, event) {
   check_message_for_command(bot, metadata, message); //check and handle cmd
   eventBus.emit("message", bot, metadata, message, event);
 });
+
+exports.getPluginRegistry = function () {
+  return plugins;
+}
+
+exports.getCommandRegistry = function () {
+  return cmds;
+}


### PR DESCRIPTION
Added support for events from PurrplingBot in plugins.

EventBus is given in init() in plugin!
Plugin registry for remember reference of plugins. Bot event handling in plugins

### Events handling usage:

In your plugin, events use:

```javascript
/* file: ./plugins/myplugin.js */

// import purrplingBot parent and get eventBus
const purrplingBot = require("../purrplingbot.js");
const eventBus = purrplingBot.getEventBus();

//define your event handler
eventBus.on("message", function(bot, metadata, message) {
  console.log("EVENT BUS WORKS! Stolen message: %s", message);
});
```

### List of events

| Event           | Args                   | Description                                               |
|-----------------|------------------------|-----------------------------------------------------------|
| commandRegister | cmd                    | Triggered when new command registered in command registry     |
| pluginLoaded    | plugin, pluginName     | Triggered when plugin loaded while plugin loading process |
| commandHandled  | cmd, message, bot      | On command was handled event                              |
| ready           |                        | PurrplingBot is ready event handler                       |
| message         | bot, metadata, message | Handles on incomming message in chat                      |

### PurrplingBot external interface

Accessing to bot properties/methods from plugins

```javascript
exports.getPluginRegistry = function () {
  return plugins; //get plugin registry
}

exports.getCommandRegistry = function () {
  return cmds; //get command registry
}

exports.getEventBus = function () {
  return eventBus; //Get event bus/emmiter
}
```