### PR TITLE
Add a stream live NOW status checker

### DIFF
--- a/config.example.json
+++ b/config.example.json
@@ -11,7 +11,12 @@
 	"twitch": {
 		"twitch_token": "l3d809cqz3r28buu2d603ayyg83g32",
 		"twitch_channel_name": "purrplingcat",
-		"twitch_channel_id": "125991922"
+		"twitch_channel_id": "125991922",
+		"twitch_stream_checker": {
+			"enabled": true,
+			"interval": 300,
+			"announceChannelId": "323516538378256395"
+		}
 	},
 	"mumblebox": "./mumblebox.json",
 	"greetings": {

--- a/plugins/Nextstream/nextstream.js
+++ b/plugins/Nextstream/nextstream.js
@@ -2,18 +2,82 @@ var request = require("request");
 var moment = require('moment');
 var PurrplingBot = require("../../purrplingbot.js");
 var config = PurrplingBot.getConfiguration();
+var client = PurrplingBot.getDiscordClient();
 var logger;
 
 const twitch_token = config.twitch.twitch_token;
 const twitch_channel_name = config.twitch.twitch_channel_name;
 const twitch_channel_id = config.twitch.twitch_channel_id;
+const twitch_stream_checker = config.twitch.twitch_stream_checker || {enabled: false, interval: 300};
+
+var previousStreamState = "OFFLINE"
+var streamInfo;
 
 exports.commands = [
   "nextstream"
-]
+];
+
+function streamLiveNowAnnounce() {
+  var request_url = "https://api.twitch.tv/v5/streams/" + twitch_channel_id + "?client_id=" + twitch_token;
+  logger.info("Checking for if %s's stream is live now ...", twitch_channel_name);
+  request({
+    url: request_url,
+    json: true,
+  }, function (error, response, body) {
+      logger.log("Request: %s", request_url);
+      if (!error && response.statusCode === 200) {
+        var channel = client.channels.find('id', twitch_stream_checker.announceChannelId);
+        if (!body.stream) {
+          logger.info("Stream is OFFLINE! Twitch channel: %s", twitch_channel_name);
+          if (previousStreamState == "ONLINE") {
+            previousStreamState = "OFFLINE";
+            if (channel) {
+              channel.send(`${streamInfo.channel.display_name} právě ukončila stream!\nTitulek streamu: **${streamInfo.channel.status}**\nHrála: **${streamInfo.channel.game}**`)
+              .then(logger.info(`Information about stream sent to #${channel.name}`))
+              .catch(logger.error);
+            } else {
+              logger.error("Can't send info about stream state to channel ID: %s - Channel not found!");
+            }
+          }
+          return;
+        }
+        logger.info("Stream is ONLINE! Twitch channel: %s", twitch_channel_name);
+        if (previousStreamState == "OFFLINE") {
+          previousStreamState = "ONLINE";
+          streamInfo = body.stream;
+          if (channel) {
+            channel.send(`@everyone ${streamInfo.channel.display_name} je právě ONLINE! Sleduj to na ${streamInfo.channel.url}\nTitulek streamu: **${streamInfo.channel.status}**\nHraje: **${streamInfo.channel.game}**`,
+               {
+                 embed: {
+                   title: streamInfo.channel.status,
+                   url: "https://www.twitch.tv/" + twitch_channel_name,
+                   image: {
+                     url: streamInfo.preview.medium
+                   }
+                 }
+               }
+             )
+            .then(logger.info(`Information about stream sent to #${channel.name}`))
+            .catch(logger.error);
+          } else {
+            logger.error("Can't send info about stream state to channel ID: %s - Channel not found!");
+          }
+        }
+      } else {
+        logger.error("An error occured while fetching stream status! Status code: %s", response.statusCode);
+        logger.dir(body);
+      }
+  });
+}
 
 exports.init = function(pluginName) {
   logger = PurrplingBot.createLogger(pluginName);
+  const stream_check_enabled = twitch_stream_checker.enabled || false;
+  const stream_check_interval = twitch_stream_checker.interval || 300;
+  if (stream_check_enabled) {
+    client.setInterval(streamLiveNowAnnounce, stream_check_interval * 1000);
+    logger.info("Stream live now checker ENABLED");
+  }
 }
 
 exports.nextstream = {


### PR DESCRIPTION
**Plugin: Nextstream**

## Feature story

This add function to plugin **Nextstream** for checking if your **stream is live now or not**. After stream status changed ONLINE<->OFFLINE, bot announce a message about stream status with stream informations to a announce channel specified by you.

Function checks status every x seconds (define by you in conf, default is 300s (5m)))

Command **!livenow** prints a current stream state to a channel on Discord.

#### Example config

```json
"twitch": {
		"twitch_token": "k7d809abc3r28buu2d6887xxg83r23",
		"twitch_channel_name": "purrplingcat",
		"twitch_channel_id": "125991922",
		"twitch_stream_checker": {
			"enabled": true,
			"interval": 300,
			"announceChannelId": "323516538378256395"
		}
```